### PR TITLE
Updates for LocalGov Geo Browser.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "localgovdrupal/localgov_geo": "dev-feature/1.x/area-and-ux-autocomplete"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "^dev-origin/feature/2.x/localgov-geo-browser"
+        "localgovdrupal/localgov_directories": "^dev-feature/2.x/localgov-geo-browser"
     },
     "extra": {
         "enable-patching": true,

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         "drupal/facets": "^1.5",
         "drupal/search_api": "^1.17",
         "localgovdrupal/localgov_core": "^2.1",
-        "localgovdrupal/localgov_geo": "^1.0"
+        "localgovdrupal/localgov_geo": "dev-feature/1.x/area-and-ux-autocomplete"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "^2.0"
+        "localgovdrupal/localgov_directories": "^dev-origin/feature/2.x/localgov-geo-browser"
     },
     "extra": {
         "enable-patching": true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "localgovdrupal/localgov_geo": "dev-feature/1.x/area-and-ux-autocomplete"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "^dev-feature/2.x/localgov-geo-browser"
+        "localgovdrupal/localgov_directories": "dev-feature/2.x/localgov-geo-browser"
     },
     "extra": {
         "enable-patching": true,

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         "drupal/facets": "^1.5",
         "drupal/search_api": "^1.17",
         "localgovdrupal/localgov_core": "^2.1",
-        "localgovdrupal/localgov_geo": "dev-feature/1.x/area-and-ux-autocomplete"
+        "localgovdrupal/localgov_geo": "^1.1"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "dev-feature/2.x/localgov-geo-browser"
+        "localgovdrupal/localgov_directories": "^1.1"
     },
     "extra": {
         "enable-patching": true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "localgovdrupal/localgov_geo": "^1.1"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "^1.1"
+        "localgovdrupal/localgov_directories": "^2.0"
     },
     "extra": {
         "enable-patching": true,

--- a/config/install/core.entity_form_display.node.localgov_event.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_event.default.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_form_mode.localgov_geo.inline
+    - entity_browser.browser.localgov_geo_library
     - field.field.node.localgov_event.body
     - field.field.node.localgov_event.localgov_event_call_to_action
     - field.field.node.localgov_event.localgov_event_categories
@@ -14,8 +14,8 @@ dependencies:
     - node.type.localgov_event
   module:
     - date_recur_modular
+    - entity_browser
     - field_group
-    - inline_entity_form
     - link
     - media_library
     - path
@@ -159,19 +159,16 @@ content:
   localgov_event_location:
     weight: 12
     settings:
-      form_mode: inline
-      override_labels: true
-      label_singular: location
-      label_plural: locations
-      collapsible: true
-      collapsed: false
-      allow_new: true
-      allow_existing: false
-      match_operator: CONTAINS
-      revision: false
-      allow_duplicate: false
+      entity_browser: localgov_geo_library
+      field_widget_display: label
+      field_widget_edit: true
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      field_widget_replace: false
+      field_widget_display_settings: {  }
     third_party_settings: {  }
-    type: inline_entity_form_complex
+    type: entity_browser_entity_reference
     region: content
   localgov_event_price:
     weight: 7

--- a/config/install/core.entity_view_display.node.localgov_event.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_event.default.yml
@@ -70,7 +70,7 @@ content:
     weight: 6
     label: hidden
     settings:
-      view_mode: default
+      view_mode: embed
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view

--- a/localgov_events.info.yml
+++ b/localgov_events.info.yml
@@ -21,4 +21,4 @@ dependencies:
   # LocalGov Drupal
   - localgov_core:localgov_core
   - localgov_core:localgov_media
-  - localgov_geo:localgov_geo
+  - localgov_geo:localgov_geo_address

--- a/localgov_events.install
+++ b/localgov_events.install
@@ -41,3 +41,18 @@ function localgov_events_install() {
     ]);
   }
 }
+
+/**
+ * Use new 'Embed' View Mode for Geo if not already altered.
+ */
+function localgov_events_update_8001() {
+  // Upgrade to LocalGov Geo copies over default to embed view mode; but removes
+  // the new label field from the template. Embed on upgrade should behave the
+  // same as Default did.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('core.entity_view_display.node.localgov_event.default');
+  if ($config->get('content.localgov_event_location.settings.view_mode') == 'default') {
+    $config->set('content.localgov_event_location.settings.view_mode', 'embed');
+    $config->save(TRUE);
+  }
+}


### PR DESCRIPTION
Synchronise release with localgovdrupal/localgov_geo#29

Also related localgovdrupal/localgov_directories#143 this update does much the same to events as directories venue:
 * Change defaults for a new install
 * Prevent regressions on existing site, with ability to configure new functionality as desired.