### PR TITLE
Fix illegal choice error with events exposed filter date widget

### DIFF
--- a/localgov_events.module
+++ b/localgov_events.module
@@ -207,6 +207,7 @@ function localgov_events_form_views_exposed_form_alter(&$form, FormStateInterfac
     $form['date_picker']['dates'] = [
       '#type' => 'select',
       '#options' => $date_options,
+      '#default_value' => 'choose',
       '#attributes' => ['class' => ['js-date-picker']],
     ];
     $form['date_picker']['start'] = [


### PR DESCRIPTION
Fix #62
Possible also #58

Sets the default value to 'choose' for the date widget so it can be sent
in the pager.
