### PR TITLE
Upgrade to Facets 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/date_recur": "^3.0",
         "drupal/date_recur_modular": "^3.0",
-        "drupal/facets": "^1.5",
+        "drupal/facets": "^2.0",
         "drupal/search_api": "^1.17",
         "localgovdrupal/localgov_core": "^2.1",
         "localgovdrupal/localgov_geo": "^1.1"


### PR DESCRIPTION
I'm marginally confused that facets is needed here; but it certainly _will_ be needed.

Upgrade is Facets dropping 8.x support and PHP 7.1 support. No schema alterations.

See also:
 * https://github.com/localgovdrupal/localgov_news/pull/52
 * https://github.com/localgovdrupal/localgov_openreferral/pull/23
 * https://github.com/localgovdrupal/localgov_directories/pull/176