### PR TITLE
Add the $is_syncing check to hook_install / installed

### DIFF
--- a/localgov_events.install
+++ b/localgov_events.install
@@ -10,7 +10,12 @@ use Drupal\taxonomy\Entity\Term;
 /**
  * Implements hook_install().
  */
-function localgov_events_install() {
+function localgov_events_install($is_syncing) {
+
+  // Don't configure the extra fields or config during config sync operations.
+  if ($is_syncing) {
+    return;
+  }
 
   // Configure optional fields.
   $directory_page = \Drupal::moduleHandler()->moduleExists('localgov_directories_page');

--- a/localgov_events.module
+++ b/localgov_events.module
@@ -92,7 +92,13 @@ function localgov_events_page_attachments(array &$attachments) {
 /**
  * Implements hook_modules_installed().
  */
-function localgov_events_modules_installed($modules) {
+function localgov_events_modules_installed($modules, $is_syncing) {
+
+  // Don't configure the extra fields during config sync operations.
+  if ($is_syncing) {
+    return;
+  }
+
   // Configure optional fields.
   $directory_page = in_array('localgov_directories_page', $modules);
   $directory_venue = in_array('localgov_directories_venue', $modules);


### PR DESCRIPTION
Fix #17

Alternative fix to #18.
Better to not modify site config or install extra fields during the config
import operation.

BHCC are running into the issue mentioned in #17, and as mentioned on the PR
#18 it may actully be prefferable not to respond to any hook_install / hook_installed events during a config sync operation.
