### PR TITLE
Add search result highlight to search result highlight display

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_event.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_event.search_result.yml
@@ -24,77 +24,21 @@ targetEntityType: node
 bundle: localgov_event
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_default
-    weight: 3
+  search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
-    region: content
-  localgov_event_call_to_action:
-    weight: 2
-    label: hidden
-    settings:
-      trim_length: null
-      url_only: false
-      url_plain: false
-      rel: '0'
-      target: '0'
-    third_party_settings: {  }
-    type: link
-    region: content
-  localgov_event_date:
-    weight: 1
-    label: hidden
-    settings:
-      format_type: localgov_event_date_full
-      occurrence_format_type: localgov_event_date_full
-      same_end_date_format_type: localgov_event_date_hour
-      separator: to
-      timezone_override: ''
-      interpreter: ''
-      show_next: 10
-      count_per_item: false
-    third_party_settings: {  }
-    type: date_recur_basic_formatter
-    region: content
-  localgov_event_image:
-    type: entity_reference_entity_view
     weight: 0
-    label: hidden
-    settings:
-      view_mode: scale_crop_7_3_large
-      link: false
-    third_party_settings: {  }
     region: content
-  localgov_event_location:
-    weight: 6
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
-  localgov_event_provider:
-    type: entity_reference_label
-    region: content
-    label: inline
-    weight: 4
-    settings:
-      link: true
-    third_party_settings: {  }
-  localgov_event_venue:
-    type: entity_reference_label
-    region: content
-    label: inline
-    weight: 5
-    settings:
-      link: true
-    third_party_settings: {  }
 hidden:
+  body: true
+  content_moderation_control: true
   links: true
+  localgov_event_call_to_action: true
   localgov_event_categories: true
+  localgov_event_date: true
+  localgov_event_image: true
   localgov_event_locality: true
+  localgov_event_location: true
   localgov_event_price: true
-  search_api_excerpt: true
+  localgov_event_provider: true
+  localgov_event_venue: true

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\Tests\localgov_events\Functional;
+
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+
+/**
+ * Tests pages working together with search, pathauto, services and topics.
+ *
+ * @group localgov_step_by_step
+ */
+class LocalgovIntegrationTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use AssertBreadcrumbTrait;
+  use TaxonomyTestTrait;
+  use CronRunTrait;
+
+  /**
+   * Test breadcrumbs in the Standard profile.
+   *
+   * @var string
+   */
+  protected $profile = 'standard';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stable';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_core',
+    'localgov_services_landing',
+    'localgov_services_sublanding',
+    'localgov_services_navigation',
+    'localgov_topics',
+    'localgov_events',
+    'localgov_search',
+    'localgov_search_db',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->drupalPlaceBlock('system_breadcrumb_block');
+    $this->adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+    ]);
+    $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
+  }
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $body = [
+      'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
+      'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
+    ];
+    $this->createNode([
+      'title' => 'Test Event',
+      'body' => $body,
+      'type' => 'localgov_event',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
+    $this->cronRun();
+
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains('Test Event');
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
+  }
+
+}

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -3,7 +3,6 @@
 namespace Drupal\Tests\localgov_events\Functional;
 
 use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;


### PR DESCRIPTION
Fix #83

Usual cavet about using search_api as dependency applies.
(If not using search_api, the search result display will be blank)
