### PR TITLE
Drupal 10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -108,13 +108,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -144,13 +144,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 
@@ -179,13 +179,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        localgov-version:
-          - '2.x'
-        drupal-version:
-          - '~9.3'
-        php-version:
-          - '7.4'
-          - '8.1'
+        include:
+          - localgov-version: '2.x'
+            drupal-version: '~9.4'
+            php-version: '8.1'
+          - localgov-version: '3.x'
+            drupal-version: '~10.0'
+            php-version: '8.1'
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ name: Test localgovdrupal/localgov_events drupal-module
 on:
   push:
     branches:
-      - '2.x'
+      - '3.x'
   pull_request:
     branches:
-      - '2.x'
+      - '3.x'
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_events
@@ -24,13 +24,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 
@@ -108,13 +107,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 
@@ -144,13 +142,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 
@@ -179,13 +176,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - localgov-version: '2.x'
-            drupal-version: '~9.4'
-            php-version: '8.1'
-          - localgov-version: '3.x'
-            drupal-version: '~10.0'
-            php-version: '8.1'
+        localgov-version:
+          - '3.x'
+        drupal-version:
+          - '~10.0'
+        php-version:
+          - '8.1'
 
     steps:
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/date_recur_modular": "^3.1@RC",
         "drupal/facets": "^2.0",
         "drupal/search_api": "^1.17",
-        "localgovdrupal/localgov_core": "dev-feature/drupal-10 as 2.2.0",
+        "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_geo": "dev-feature/drupal-10 as 1.3.0",
         "rlanvin/php-rrule": "^1.0|^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "drupal/date_recur_modular": "^3.0",
         "drupal/facets": "^2.0",
         "drupal/search_api": "^1.17",
-        "localgovdrupal/localgov_core": "^2.1",
-        "localgovdrupal/localgov_geo": "^1.1",
+        "localgovdrupal/localgov_core": "dev-feature/drupal-10 as 2.2.0",
+        "localgovdrupal/localgov_geo": "dev-feature/drupal-10 as 1.3.0",
         "rlanvin/php-rrule": "^1.0|^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/date_recur": "^3.2",
-        "drupal/date_recur_modular": "3.x-dev#6ea45215",
+        "drupal/date_recur_modular": "^3.1@RC",
         "drupal/facets": "^2.0",
         "drupal/search_api": "^1.17",
         "localgovdrupal/localgov_core": "dev-feature/drupal-10 as 2.2.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/date_recur": "^3.0",
+        "drupal/date_recur": "^3.2",
         "drupal/date_recur_modular": "^3.0",
         "drupal/facets": "^2.0",
         "drupal/search_api": "^1.17",
@@ -25,7 +25,8 @@
         },
         "patches": {
             "drupal/date_recur_modular": {
-                "Date validation #3154944": "https://www.drupal.org/files/issues/2020-06-25/alpha-modal-form-end-date-validation.patch"
+                "Date validation #3154944": "https://www.drupal.org/files/issues/2020-06-25/alpha-modal-form-end-date-validation.patch",
+                "Drupal 10 support #3296930": "https://www.drupal.org/files/issues/2022-12-27/3296930-5.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/date_recur": "^3.2",
-        "drupal/date_recur_modular": "^3.0",
+        "drupal/date_recur_modular": "3.x-dev#6ea45215",
         "drupal/facets": "^2.0",
         "drupal/search_api": "^1.17",
         "localgovdrupal/localgov_core": "dev-feature/drupal-10 as 2.2.0",
@@ -25,9 +25,7 @@
         },
         "patches": {
             "drupal/date_recur_modular": {
-                "Date validation #3154944": "https://www.drupal.org/files/issues/2020-06-25/alpha-modal-form-end-date-validation.patch",
-                "Drupal 10 support #3296930": "https://www.drupal.org/files/issues/2022-12-27/3296930-5.patch"
-            }
+                "Date validation #3154944": "https://www.drupal.org/files/issues/2020-06-25/alpha-modal-form-end-date-validation.patch"            }
         }
     }
 }

--- a/config/install/core.entity_form_display.node.localgov_event.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_event.default.yml
@@ -110,7 +110,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:

--- a/config/optional/field.field.node.localgov_event.localgov_event_provider.yml
+++ b/config/optional/field.field.node.localgov_event.localgov_event_provider.yml
@@ -20,7 +20,6 @@ settings:
   handler_settings:
     target_bundles:
       localgov_directories_page: localgov_directories_page
-      localgov_directories_venue: localgov_directories_venue
     sort:
       field: _none
     auto_create: false

--- a/localgov_events.info.yml
+++ b/localgov_events.info.yml
@@ -1,6 +1,6 @@
 name: LocalGov Events
 description: Provides events for LocalGov Drupal.
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9 || ^10
 type: module
 package: LocalGov Drupal
 

--- a/localgov_events.install
+++ b/localgov_events.install
@@ -39,8 +39,8 @@ function localgov_events_install($is_syncing) {
   // in the config/optional folder.
   // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
   if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
-    $generator = \Drupal::service('simple_sitemap.generator');
-    $generator->setBundleSettings('node', 'localgov_event', [
+    $entity_manager = \Drupal::service('simple_sitemap.entity_manager');
+    $entity_manager->setBundleSettings('node', 'localgov_event', [
       'index' => TRUE,
       'priority' => 0.5,
     ]);

--- a/localgov_events.module
+++ b/localgov_events.module
@@ -102,10 +102,17 @@ function localgov_events_modules_installed($modules, $is_syncing) {
   // Configure optional fields.
   $directory_page = in_array('localgov_directories_page', $modules);
   $directory_venue = in_array('localgov_directories_venue', $modules);
-  if ($directory_page || $directory_venue) {
-    \Drupal::service('config.installer')->installOptionalConfig();
-    localgov_events_optional_fields_settings($directory_page, $directory_venue);
+  if ($directory_page) {
+    \Drupal::service('config.installer')->installOptionalConfig(NULL, [
+      'config' => 'node.type.localgov_directories_page',
+    ]);
   }
+  if ($directory_venue) {
+    \Drupal::service('config.installer')->installOptionalConfig(NULL, [
+      'config' => 'node.type.localgov_directories_venue',
+    ]);
+  }
+  localgov_events_optional_fields_settings($directory_page, $directory_venue);
 }
 
 /**

--- a/localgov_events.module
+++ b/localgov_events.module
@@ -8,9 +8,9 @@
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\views\ViewExecutable;
 use Drupal\localgov_events\Form\EventsAddEditCallbacks;
 use Drupal\localgov_roles\RolesHelper;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_theme().

--- a/tests/src/Functional/EventPageTest.php
+++ b/tests/src/Functional/EventPageTest.php
@@ -16,7 +16,7 @@ class EventPageTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'minimal';
+  protected $profile = 'testing';
 
   /**
    * Test using the stark theme.

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -26,12 +26,12 @@ class LocalgovIntegrationTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $profile = 'standard';
+  protected $profile = 'testing';
 
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to bypass content access checks.


### PR DESCRIPTION
There needs to be a major release of LocalGov Geo fro Drupal support (https://github.com/localgovdrupal/localgov_geo/issues/65#issuecomment-1447093730), which as a dependency of Events, requires a major version bump for Events.

This will require a 3.x release.

Fixes #91 