### PR TITLE
Show summary on event edit form

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_event.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_event.default.yml
@@ -110,7 +110,7 @@ content:
       rows: 9
       summary_rows: 3
       placeholder: ''
-      show_summary: false
+      show_summary: true
     third_party_settings: {  }
     region: content
   created:


### PR DESCRIPTION
Fixes  #97

With this change the event edit page looks like:

![image](https://user-images.githubusercontent.com/7189914/236249261-8b64619c-47e4-4e15-b7b5-ec3c0dd1c025.png)
