### PR TITLE
Add patch for date_recur create occurances for default revision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "date_recur": {
+                "Create occurrences for latest and default versions #3010184": "https://www.drupal.org/files/issues/2019-06-22/date_recur-save-default-rev-occurances-3010184-6.patch"
+            },
             "drupal/date_recur_modular": {
                 "Date validation #3154944": "https://www.drupal.org/files/issues/2020-06-25/alpha-modal-form-end-date-validation.patch"            }
         }


### PR DESCRIPTION
Fix #143

Adds the patch from
  https://www.drupal.org/project/date_recur/issues/3010184#comment-13156851
  (comment 6).

This allows events that have been published to be moved to draft or review and still show on the events calendar, as the default (published) revision will retian it's calculated dates used by views.
