### PR TITLE
Mark support for Drupal 11 and drop Drupal 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "rlanvin/php-rrule": "^1.0|^2.0"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "^3.0"
+        "localgovdrupal/localgov_directories": "dev-feature/3.x/394-drupal-11-support as 3.2.2"
     },
     "extra": {
         "enable-patching": true,

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "rlanvin/php-rrule": "^1.0|^2.0"
     },
     "require-dev": {
-        "localgovdrupal/localgov_directories": "dev-feature/3.x/394-drupal-11-support as 3.2.2"
+        "localgovdrupal/localgov_directories": "^3.0"
     },
     "extra": {
         "enable-patching": true,

--- a/localgov_events.info.yml
+++ b/localgov_events.info.yml
@@ -1,6 +1,6 @@
 name: LocalGov Events
 description: Provides events for LocalGov Drupal.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 


### PR DESCRIPTION
Running upgrade status highlighted that this module was not compatible with Drupal 11. This pr adds in Drupal 11 support and drops Drupal 9.

Fixes #158 