### PR TITLE
Delete old events

### DIFF
--- a/modules/localgov_events_purge/README.md
+++ b/modules/localgov_events_purge/README.md
@@ -1,0 +1,30 @@
+## INTRODUCTION
+
+The LocalGov Events Purge module is a DESCRIBE_THE_MODULE_HERE.
+
+The primary use case for this module is:
+
+- Use case #1
+- Use case #2
+- Use case #3
+
+## REQUIREMENTS
+
+DESCRIBE_MODULE_DEPENDENCIES_HERE
+
+## INSTALLATION
+
+Install as you would normally install a contributed Drupal module.
+See: https://www.drupal.org/node/895232 for further information.
+
+## CONFIGURATION
+- Configuration step #1
+- Configuration step #2
+- Configuration step #3
+
+## MAINTAINERS
+
+Current maintainers for Drupal 10:
+
+- FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
+

--- a/modules/localgov_events_purge/localgov_events_purge.info.yml
+++ b/modules/localgov_events_purge/localgov_events_purge.info.yml
@@ -1,0 +1,7 @@
+name: 'LocalGov Events Purge'
+type: module
+description: 'Deletes events a certain number of days after their deadline.'
+package: LocalGov Drupal
+core_version_requirement: ^10 || ^11
+dependencies:
+  - localgov_events:localgov_events

--- a/modules/localgov_events_purge/localgov_events_purge.install
+++ b/modules/localgov_events_purge/localgov_events_purge.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the LocalGov Events Purge module.
+ */

--- a/modules/localgov_events_purge/localgov_events_purge.module
+++ b/modules/localgov_events_purge/localgov_events_purge.module
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for LocalGov Events Purge module.
+ */
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_cron().
+ */
+function localgov_events_purge_cron() {
+  // @TODO: create a config form for purge timeframe.
+
+  $config = \Drupal::config('localgov_events_purge.settings');
+  $purge_after = $config->get('purge_after');
+  $purge_after = $purge_after ? $purge_after : 30;
+  $purge_after = '-' . $purge_after . ' days';
+
+  $query = \Drupal::entityQuery('node')
+    ->condition('type', 'localgov_event')
+    ->accessCheck(TRUE); // Explicitly set access check
+
+  $nids = $query->execute();
+
+  if (!empty($nids)) {
+    $nodes = Node::loadMultiple($nids);
+    foreach ($nodes as $node) {
+      $end_date = $node->get('localgov_event_date')->end_value;
+      // Convert $end_date to timestamp.
+      $end_date = strtotime($end_date);
+      if ($end_date < strtotime($purge_after)) {
+        // Let's use dump() for now, so we don't delete nodes.
+        // It takes too long to recreate them :)
+        dump($node->id() . ' will be deleted');
+        // $node->delete();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Test, but do not merge

Closes #114 

## What does this change?

Currently this does very little - loads all events, checks if their end_date is passed by 30 days, then deletes them if so.

We need to do LOTS of work to get this to work properly

- [ ] Create settings form
- [ ] Get it to work with rrule

## How to test

Create some events, run cron, you should get a `dump()` message to say what will/will not be deleted.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)