### PR TITLE
Fix default timezone as parsed by date_recur on initial submission. Fixes #184

### DIFF
--- a/config/install/field.field.node.localgov_event.localgov_event_date.yml
+++ b/config/install/field.field.node.localgov_event.localgov_event_date.yml
@@ -24,6 +24,7 @@ default_value:
     default_end_date: now
     default_date_time_zone: Europe/London
     default_time_zone: Europe/London
+    default_time_zone_source: fixed
     default_rrule: ''
 default_value_callback: ''
 settings:

--- a/localgov_events.install
+++ b/localgov_events.install
@@ -5,6 +5,7 @@
  * LocalGov Events install file.
  */
 
+use Drupal\field\Entity\FieldConfig;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -71,5 +72,26 @@ function localgov_events_update_8002() {
   if ($config->get('pattern') == 'l, jS F Y, g.ia') {
     $config->set('pattern', 'l j F Y, g.ia');
     $config->save(TRUE);
+  }
+}
+
+/**
+ * Set default timezone correctly.
+ *
+ * @see localgovdrupal/localgov_evenst#184
+ */
+function localgov_events_update_8003() {
+  $field = FieldConfig::load('node.localgov_event.localgov_event_date');
+  $default_values = $field->getDefaultValueLiteral();
+  $changed = FALSE;
+  foreach ($default_values as $delta => $value) {
+    if (!isset($value['default_time_zone_source'])) {
+      $default_values[$delta]['default_time_zone_source'] = 'fixed';
+      $changed = TRUE;
+    }
+  }
+  if ($changed) {
+    $field->setDefaultValue($default_values);
+    $field->save();
   }
 }

--- a/localgov_events.install
+++ b/localgov_events.install
@@ -80,7 +80,7 @@ function localgov_events_update_8002() {
  *
  * @see localgovdrupal/localgov_evenst#184
  */
-function localgov_events_update_8003() {
+function localgov_events_update_8003(): void {
   $field = FieldConfig::load('node.localgov_event.localgov_event_date');
   $default_values = $field->getDefaultValueLiteral();
   $changed = FALSE;


### PR DESCRIPTION
Add the required `default_time_zone_source` key to our default configuration.
Update existing configuration adding the key, if it does not already exist (safe for existing sites that have updated their config, safe for runing on dev exporting config and importing into prod where the update will run again).

Fixes #184 by ensuring the default timezone is passed into the validation of the date_recur field from the get-go (like when Entity Browser causes an early for rebuild).