### PR TITLE
Fix tests in Drupal 11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/date_recur_modular": "^3.1@RC",
         "drupal/facets": "^2.0 || ^3.0",
         "drupal/search_api": "^1.17",
-        "localgovdrupal/localgov_core": "2.14.13",
+        "localgovdrupal/localgov_core": "^2.14.13",
         "localgovdrupal/localgov_geo": "^2.0",
         "rlanvin/php-rrule": "^1.0|^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/date_recur_modular": "^3.1@RC",
         "drupal/facets": "^2.0 || ^3.0",
         "drupal/search_api": "^1.17",
-        "localgovdrupal/localgov_core": "dev-feature/media-test-config as 2.15.0",
+        "localgovdrupal/localgov_core": "2.14.13",
         "localgovdrupal/localgov_geo": "^2.0",
         "rlanvin/php-rrule": "^1.0|^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/date_recur_modular": "^3.1@RC",
         "drupal/facets": "^2.0 || ^3.0",
         "drupal/search_api": "^1.17",
-        "localgovdrupal/localgov_core": "^2.12",
+        "localgovdrupal/localgov_core": "dev-feature/media-test-config as 2.15.0",
         "localgovdrupal/localgov_geo": "^2.0",
         "rlanvin/php-rrule": "^1.0|^2.0"
     },

--- a/tests/src/Functional/EventPageTest.php
+++ b/tests/src/Functional/EventPageTest.php
@@ -82,6 +82,7 @@ class EventPageTest extends BrowserTestBase {
   protected static $modules = [
     'field_ui',
     'localgov_events',
+    'localgov_media_test_config',
   ];
 
   /**

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -100,6 +100,7 @@ class LocalgovIntegrationTest extends BrowserTestBase {
     'localgov_events',
     'localgov_search',
     'localgov_search_db',
+    'localgov_media_test_config',
   ];
 
   /**


### PR DESCRIPTION
## What does this change?

Uses [localgov_media_test_config](https://github.com/localgovdrupal/localgov_core/tree/feature/media-test-config) module in tests.

## How to test

Tests should all pass when run with Drupal 11.2
