### PR TITLE
3.1.0 release

### DIFF
--- a/modules/localgov_events_remove_expired/README.md
+++ b/modules/localgov_events_remove_expired/README.md
@@ -1,0 +1,41 @@
+# LocalGov Drupal Events remove expired
+
+Provides a way to remove expired events - either by deletion or unpublishing/archiving
+A sub-module of localgov_events and works with or without content moderation.
+
+If content moderation is on, this works with the localgov workflow and will set the events to expired when archive is selected.  
+If moderation is not in use and archive is selected, the event will be unpublished. 
+Unpublishing and deletion of the events are handled by cron, so please make sure a cron job is configured.
+
+Configuration form can be found here - /admin/config/content/expired-events
+
+## Testing expiring events (@see \Drupal\Tests\localgov_events_remove_expired\Functional\ExpiredEventsTest)
+
+Creates an array of events 
+
+past_event          - 1 day past expiry period - date adjustment ` -(expiry_days + 1)`
+expiry_period_event - matches the expiry period - date adjustment ` -(expiry_days)`
+today_event         - 0 days old - date adjustment `0`
+future_event        - an expiry period in the future - date adjustment ` +(expiry_days)`
+recurring_event     - starts 2 days ago and recurs for 10 days  - date adjustment `-2 and continue for 10days`
+
+
+Which tests that event deletion/unpublishing only happens for past_event in each case
+
+### Sample results
+
+**Date of sample run:  01-10-2025**
+
+
+**Expiry period**                                             |              0               |              1               |              15                       
+——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+**Past**                                                      |          30-09-2025          |          29-09-2025          |          15-09-2025 
+——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+**Expiry period in past**                                     |          01-10-2025          |          30-09-2025          |          16-09-2025 
+——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+**Today**                                                     |          01-10-2025          |          01-10-2025          |          01-09-2025 
+——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+**Forward Expiry period in future**                           |          01-10-2025          |          02-10-2025          |          16-10-2025 
+——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+**Recurring event 2 days in past then forward 10 days**       |          29-09-2025+         |          29-09-2025+         |          29-09-2025+
+——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

--- a/modules/localgov_events_remove_expired/config/install/localgov_events_remove_expired.settings.yml
+++ b/modules/localgov_events_remove_expired/config/install/localgov_events_remove_expired.settings.yml
@@ -1,0 +1,3 @@
+action: none
+expire_days: 30
+items_per_cron: 100

--- a/modules/localgov_events_remove_expired/config/schema/localgov_expired_events.schema.yml
+++ b/modules/localgov_events_remove_expired/config/schema/localgov_expired_events.schema.yml
@@ -1,0 +1,21 @@
+localgov_events_remove_expired.settings:
+  type: config_entity
+  label: 'Remove expired events module settings'
+  mapping:
+    action:
+      type: string
+      label: 'Action type'
+    expire_days:
+      type: integer
+      label: 'number of days'
+      constraints:
+        Regex:
+          pattern: '/^[0-9]+$/'
+          message: 'Please enter numbers only'
+    items_per_cron:
+      type: integer
+      label: 'Items per cron'
+      constraints:
+        Regex:
+          pattern: '/^[0-9]+$/'
+          message: 'Please enter numbers only'

--- a/modules/localgov_events_remove_expired/localgov_events_remove_expired.info.yml
+++ b/modules/localgov_events_remove_expired/localgov_events_remove_expired.info.yml
@@ -1,0 +1,7 @@
+name: LocalGov Events remove expired
+description: Archive/Unpublished or delete expired events when cron is excuted.
+package: LocalGov Drupal
+type: module
+core_version_requirement: ^9 || ^10 ||  ^11
+dependencies:
+  - localgov_events:localgov_events

--- a/modules/localgov_events_remove_expired/localgov_events_remove_expired.links.menu.yml
+++ b/modules/localgov_events_remove_expired/localgov_events_remove_expired.links.menu.yml
@@ -1,0 +1,6 @@
+localgov_events_remove_expired.admin.settings:
+  title: 'Expired Events Settings'
+  description: 'Expired events settings'
+  parent: 'system.admin_config_content'
+  route_name: localgov_events_remove_expired.form
+  weight: 100

--- a/modules/localgov_events_remove_expired/localgov_events_remove_expired.module
+++ b/modules/localgov_events_remove_expired/localgov_events_remove_expired.module
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * @file
+ * Provides event deletion/archiving support.
+ */
+
+use Drupal\content_moderation\Entity\ContentModerationState;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\date_recur\DateRecurOccurrences;
+
+/**
+ * @file
+ * Contains localgov_events_remove_expired.module.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function localgov_events_remove_expired_cron(): void {
+
+  $config = \Drupal::config('localgov_events_remove_expired.settings');
+  $noOfDaysInExpiryPeriod = $config->get('expire_days');
+  $items_per_cron = $config->get('items_per_cron');
+  $action = $config->get('action');
+
+  try {
+
+    $date = new DrupalDateTime('now', 'UTC');
+    $date->modify('midnight');
+    // Increase the date by the number of days to expire.
+    $date->modify("-$noOfDaysInExpiryPeriod days");
+    // Format the date to match the database format.
+    $lastDayBeforeExpiry = $date->format('Y-m-d\TH:i:s');
+
+    $database = \Drupal::database();
+
+    // Check that the localgov_event node type exists.
+    $node_type = \Drupal::entityTypeManager()->getStorage('node_type')->load('localgov_event');
+    if (!$node_type) {
+      \Drupal::logger('localgov_events_remove_expired')->error('The localgov_event node type does not exist.');
+      return;
+    }
+    // Check that the localgov_event_date field exists.
+    $fieldDefinitions = \Drupal::service('entity_field.manager')->getFieldDefinitions('node', 'localgov_event');
+    if (!isset($fieldDefinitions['localgov_event_date'])) {
+      \Drupal::logger('localgov_events_remove_expired')->error('The localgov_event_date field does not exist on the localgov_event node type.');
+      return;
+    }
+    // Check that the localgov_event_date field is a date_recur field.
+    if ($fieldDefinitions['localgov_event_date']->getType() !== 'date_recur') {
+      \Drupal::logger('localgov_events_remove_expired')->error('The localgov_event_date field is not a date_recur field.');
+      return;
+    }
+
+    // Get the table name for the date_recur occurrences.
+    $fieldStorageDefinitions = \Drupal::service('entity_field.manager')->getFieldStorageDefinitions('node');
+    $occurrenceTableName = DateRecurOccurrences::getOccurrenceCacheStorageTableName($fieldStorageDefinitions['localgov_event_date']);
+
+    // We need to interrogate the database here, because there isn't a way
+    // (as far as we can tell) of using an entity query to load events
+    // with their recurring date instances, we just get rrules we need to
+    // query the date_recur occurrences table directly and join that to
+    // the node table.
+    // @see Drupal\date_recur\Plugin\views\filter\DateRecurFilter;
+    // Get the set of events that are ongoing or future.
+    $ongoingOrFutureEvents = $database->select($occurrenceTableName, 'dr')
+      ->distinct(TRUE)
+      ->fields('dr', ['entity_id'])
+      ->condition("dr.localgov_event_date_end_value", $lastDayBeforeExpiry, ">=");
+
+    // Get the set of events that are expired.
+    $pastEvents = $database->select($occurrenceTableName, 'dr2')
+      ->distinct(TRUE)
+      ->fields('dr2', ['entity_id'])
+      ->condition("dr2.localgov_event_date_end_value", $lastDayBeforeExpiry, "<");
+
+    // Exclude ongoing/future set of events
+    // so that we only get events which are
+    // entirely in the past.
+    $pastEvents->condition('dr2.entity_id', $ongoingOrFutureEvents, 'NOT IN');
+
+    // Join to node_field_data to get only published status.
+    $pastEvents->join('node_field_data', 'nfd', 'dr2.entity_id = nfd.nid AND nfd.status = 1');
+
+    if ($items_per_cron > 0) {
+      $pastEvents->range(0, $items_per_cron);
+    }
+
+    // Execute the query.
+    $eventsOnlyInThePast = $pastEvents->execute()->fetchAll();
+
+    // Loop through returned record.
+    if (!empty($eventsOnlyInThePast)) {
+      foreach ($eventsOnlyInThePast as $record) {
+        $entity = \Drupal::entityTypeManager()->getStorage('node')->load($record->entity_id);
+
+        // Are we doing a straight delete?
+        if ($action == 'delete') {
+          $entity->delete();
+          \Drupal::logger('localgov_events_remove_expired')->info('The status of event id = @id has been deleted.', ['@id' => $entity->id()]);
+        }
+        elseif ($action == 'unpublish') {
+
+          // If content moderation is enabled
+          // and the entity has a moderation state field.
+          // then set the moderation state to 'archived'.
+          $moduleHandler = \Drupal::service('module_handler');
+          if ($moduleHandler->moduleExists('content_moderation') && $entity->hasField('moderation_state')) {
+            $content_moderation_state = ContentModerationState::loadFromModeratedEntity($entity);
+            // In workflow terms unpublished equates to archived.
+            localgov_events_remove_expired__set_content_state($content_moderation_state, $entity, 'archived');
+            \Drupal::logger('localgov_events_remove_expired')->info('The status of event id = @id has been changed to archived.', ['@id' => $entity->id()]);
+          }
+          else {
+            // Handle non content moderation update by unpublishing.
+            $entity->setUnpublished();
+            $entity->save();
+            \Drupal::logger('localgov_events_remove_expired')->info('Event id = @id has been unpublished.', ['@id' => $entity->id()]);
+          }
+        }
+        else {
+          \Drupal::logger('localgov_events_remove_expired')->error('No action has been specified.');
+        }
+      }
+    }
+    else {
+      \Drupal::logger('localgov_events_remove_expired')->info('No expired events found to process.');
+    }
+
+  }
+  catch (Exception $e) {
+    \Drupal::logger('localgov_events_remove_expired')->error($e->getMessage());
+  }
+}
+
+/**
+ * Update content moderation state.
+ */
+function localgov_events_remove_expired__set_content_state($content_moderation_state, $entity, $state): void {
+  // Check if there is workflow applied on the node.
+  // Set the node status to archived.
+  if ($content_moderation_state) {
+    $workflow = $content_moderation_state->get('workflow')->entity;
+    $state_label = $workflow->get('type_settings')['states'];
+    if (in_array($state, array_keys($state_label), $strict = TRUE)) {
+      $entity->set('moderation_state', 'archived');
+      $entity->save();
+    }
+  }
+}

--- a/modules/localgov_events_remove_expired/localgov_events_remove_expired.permissions.yml
+++ b/modules/localgov_events_remove_expired/localgov_events_remove_expired.permissions.yml
@@ -1,0 +1,4 @@
+administer expired events:
+  title: 'Administer expired events'
+  description: 'Admin page for expired event - /admin/config/content/expired-events'
+  restrict access: TRUE

--- a/modules/localgov_events_remove_expired/localgov_events_remove_expired.routing.yml
+++ b/modules/localgov_events_remove_expired/localgov_events_remove_expired.routing.yml
@@ -1,0 +1,7 @@
+localgov_events_remove_expired.form:
+  path: '/admin/config/content/expired-events'
+  defaults:
+    _form: '\Drupal\localgov_events_remove_expired\Form\ExpiredEventSettingsForm'
+    _title: 'Expired Event Settings'
+  requirements:
+    _permission: 'administer expired events'

--- a/modules/localgov_events_remove_expired/src/Form/ExpiredEventSettingsForm.php
+++ b/modules/localgov_events_remove_expired/src/Form/ExpiredEventSettingsForm.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\localgov_events_remove_expired\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configure expired event settings for this site.
+ */
+class ExpiredEventSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'localgov_events_remove_expired_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    $form['markup_intro'] = ['#markup' => $this->t('<p><strong>Action to take on events after they expire</strong></p>')];
+
+    $form['action'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('When events have expired:'),
+      '#options' => [
+        'none' => $this->t('Do nothing'),
+        'unpublish' => $this->t('Unpublish'),
+        'delete' => $this->t('Delete'),
+      ],
+      '#config_target' => 'localgov_events_remove_expired.settings:action',
+      '#description' => $this->t('Warning: deleted events are removed from the database and may not be recoverable.'),
+    ];
+
+    $form['expire_days'] = [
+      '#type' => 'number',
+      '#title' => $this->t('How many days after events expire should action be taken?'),
+      '#min' => 0,
+      '#step' => 1,
+      '#description' => $this->t('The action will take place after midnight following the event end date.'),
+      '#config_target' => 'localgov_events_remove_expired.settings:expire_days',
+    ];
+
+    $form['items_per_cron'] = [
+      '#type' => 'number',
+      '#title' => $this->t('The events will be processed in batches by a cron run. How many events in a batch?'),
+      '#min' => 0,
+      '#step' => 1,
+      '#config_target' => 'localgov_events_remove_expired.settings:items_per_cron',
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'localgov_events_remove_expired.settings',
+    ];
+  }
+
+}

--- a/modules/localgov_events_remove_expired/src/tests/Functional/ExpiredEventsTest.php
+++ b/modules/localgov_events_remove_expired/src/tests/Functional/ExpiredEventsTest.php
@@ -1,0 +1,558 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\localgov_events_remove_expired\Functional;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\Traits\Core\CronRunTrait;
+use Drupal\workflows\Entity\Workflow;
+
+/**
+ * Confirm the module's date functionality works with expired events.
+ *
+ * @group localgov_events_remove_expired
+ */
+class ExpiredEventsTest extends BrowserTestBase {
+
+  use CronRunTrait;
+
+  /**
+   * Skip schema checks.
+   *
+   * @var string[]
+   */
+  protected static $configSchemaCheckerExclusions = [
+    // Missing schema:
+    // - 'content.location.settings.reset_map.position'.
+    // - 'content.location.settings.weight'.
+    'core.entity_view_display.localgov_geo.area.default',
+    'core.entity_view_display.localgov_geo.area.embed',
+    'core.entity_view_display.localgov_geo.area.full',
+    'core.entity_view_display.geo_entity.area.default',
+    'core.entity_view_display.geo_entity.area.embed',
+    'core.entity_view_display.geo_entity.area.full',
+    // Missing schema:
+    // - content.location.settings.geometry_validation.
+    // - content.location.settings.multiple_map.
+    // - content.location.settings.leaflet_map.
+    // - content.location.settings.height.
+    // - content.location.settings.height_unit.
+    // - content.location.settings.hide_empty_map.
+    // - content.location.settings.disable_wheel.
+    // - content.location.settings.gesture_handling.
+    // - content.location.settings.popup.
+    // - content.location.settings.popup_content.
+    // - content.location.settings.leaflet_popup.
+    // - content.location.settings.leaflet_tooltip.
+    // - content.location.settings.map_position.
+    // - content.location.settings.weight.
+    // - content.location.settings.icon.
+    // - content.location.settings.leaflet_markercluster.
+    // - content.location.settings.feature_properties.
+    'core.entity_form_display.geo_entity.address.default',
+    'core.entity_form_display.geo_entity.address.inline',
+    // Missing schema:
+    // - content.postal_address.settings.providers.
+    // - content.postal_address.settings.geocode_geofield.
+    'core.entity_form_display.localgov_geo.address.default',
+    'core.entity_form_display.localgov_geo.address.inline',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Test using the minimal profile.
+   *
+   * @var string
+   */
+  protected $profile = 'testing';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field_ui',
+    'localgov_events_remove_expired',
+    'localgov_events',
+    'node',
+    'date_recur',
+    'content_moderation',
+    'views',
+    'localgov_workflows',
+    'workflows',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+      'administer node fields',
+      'access content overview',
+    ]);
+    $this->drupalLogin($this->adminUser);
+
+  }
+
+  /**
+   * Tests that expired events are unpublished.
+   *
+   * Uses various expiry periods.
+   */
+  public function testUnpublishEvents(): void {
+    $this->unpublishEvents(0);
+    $this->unpublishEvents(1);
+    $this->unpublishEvents(15);
+  }
+
+  /**
+   * Tests that expired events are deleted.
+   *
+   * Uses various expiry periods.
+   */
+  public function testDeleteEvents(): void {
+    $this->deleteEvents(0);
+    $this->deleteEvents(1);
+    $this->deleteEvents(15);
+  }
+
+  /**
+   * Tests that expired events are unpublished.
+   *
+   * Uses various expiry periods
+   * and content moderation is not enabled.
+   */
+  public function testUnpublishEventsNonWorkflow(): void {
+    $this->unpublishEventsNonWorkflow(0);
+    $this->unpublishEventsNonWorkflow(1);
+    $this->unpublishEventsNonWorkflow(15);
+  }
+
+  /**
+   * Tests that expired event is unpublished when necessary.
+   *
+   * Creates an array of events:
+   *
+   *  Past event - 1 day past expiry period
+   *  Expiry period event - matches the expiry period
+   *  Todays event - 0 days old
+   *  Future event - an expiry period in the future
+   *  Recurring event - starts 2 days ago and recurs for 10 days
+   *
+   * all events except the past event should remain published.
+   *
+   * @param int $expiryPeriod
+   *   The number of days after which an event expires.
+   */
+  private function unpublishEvents(int $expiryPeriod): void {
+
+    // Set up the events.
+    $events = $this->createEvents($expiryPeriod, TRUE);
+
+    // Set up the configuration to unpublish events.
+    $config = \Drupal::configFactory()->getEditable('localgov_events_remove_expired.settings');
+    $config->set('expire_days', $expiryPeriod)
+      ->set('items_per_cron', 6)
+      ->set('action', 'unpublish')
+      ->save();
+
+    $this->cronRun();
+
+    // The past event should be unpublished.
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['past_event']->id());
+    $this->assertEquals("0", $refreshed_event->get('status')->value, 'Past event status should remain unpublished');
+
+    // All others should remain published.
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['expiry_period_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, $expiryPeriod . ' day old event status should remain published');
+
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['today_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, 'Todays event status should remain published');
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['future_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, 'Future status should remain published');
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['recurring_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, 'Recurring event status should remain published');
+
+  }
+
+  /**
+   * Tests that expired events are deleted when necessary.
+   *
+   * Creates an array of events:
+   *
+   *  Past event - 1 day past expiry period
+   *  Expiry period event - matches the expiry period
+   *  Todays event - 0 days old
+   *  Future event - an expiry period in the future
+   *  Recurring event - starts 2 days ago and recurs for 10 days
+   *
+   * all events except the past event should remain published.
+   *
+   * @param int $expiryPeriod
+   *   The number of days after which an event expires.
+   */
+  private function deleteEvents(int $expiryPeriod): void {
+
+    // Set up the events.
+    $events = $this->createEvents($expiryPeriod, TRUE);
+
+    // Set up the configuration to delete events.
+    $config = \Drupal::configFactory()->getEditable('localgov_events_remove_expired.settings');
+    $config->set('expire_days', $expiryPeriod)
+      ->set('items_per_cron', 6)
+      ->set('action', 'delete')
+      ->save();
+
+    $this->cronRun();
+
+    // The past event should be deleted.
+    $this->assertNull(\Drupal::entityTypeManager()->getStorage('node')->load($events['past_event']->id()), 'Past event should be deleted.');
+
+    // All others should remain.
+    $this->assertNotNull(\Drupal::entityTypeManager()->getStorage('node')->load($events['expiry_period_event']->id()), $expiryPeriod . ' day old event should not be deleted');
+    $this->assertNotNull(\Drupal::entityTypeManager()->getStorage('node')->load($events['today_event']->id()), 'Todays event should not be deleted.');
+    $this->assertNotNull(\Drupal::entityTypeManager()->getStorage('node')->load($events['future_event']->id()), 'Future event should not be deleted.');
+    $this->assertNotNull(\Drupal::entityTypeManager()->getStorage('node')->load($events['recurring_event']->id()), 'Recurring event should not be deleted.');
+
+  }
+
+  /**
+   * Tests that expired event is unpublished when necessary.
+   *
+   * Creates an array of events:
+   *
+   *  Past event - 1 day past expiry period
+   *  Expiry period event - matches the expiry period
+   *  Todays event - 0 days old
+   *  Future event - an expiry period in the future
+   *  Recurring event - starts 2 days ago and recurs for 10 days
+   *
+   * all events except the past event should remain published.
+   *
+   * @param int $expiryPeriod
+   *   The number of days after which an event expires.
+   */
+  private function unpublishEventsNonWorkflow(int $expiryPeriod): void {
+
+    // Remove the workflow from the localgov_event content type.
+    $entity = Workflow::load('localgov_editorial');
+    $type = $entity->getTypePlugin();
+    $type->removeEntityTypeAndBundle('node', 'localgov_event');
+    $entity->save();
+
+    // Set up the events.
+    $events = $this->createEvents($expiryPeriod, FALSE);
+
+    // Set up the configuration to unpublish events.
+    $config = \Drupal::configFactory()->getEditable('localgov_events_remove_expired.settings');
+    $config->set('expire_days', $expiryPeriod)
+      ->set('items_per_cron', 6)
+      ->set('action', 'unpublish')
+      ->save();
+
+    $this->cronRun();
+
+    // The past event should be unpublished.
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['past_event']->id());
+    $this->assertEquals("0", $refreshed_event->get('status')->value, 'This event status should remain published');
+
+    // All others should remain published.
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['expiry_period_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, $expiryPeriod . ' day old event status should remain published');
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['today_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, 'Todays event status should remain published');
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['future_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, 'Future status should remain published');
+    $refreshed_event = \Drupal::entityTypeManager()->getStorage('node')->load($events['recurring_event']->id());
+    $this->assertEquals("1", $refreshed_event->get('status')->value, 'Recurring event status should remain published');
+  }
+
+  /**
+   * Tests cron handling.
+   *
+   * Creates 10 events in the past
+   * set items_per_cron to 3
+   * runs cron
+   * test 3 unpublished.
+   */
+  public function testUnpublishCronBatching(): void {
+
+    // Create a bunch of event nodes.
+    $count = 10;
+
+    for ($i = 1; $i <= $count; $i++) {
+
+      $past_event = $this->drupalCreateNode([
+        'type' => 'localgov_event',
+        'title' => "Event " . $count,
+        'body' => ["value" => "Event " . $this->randomMachineName(8)],
+        'status' => NodeInterface::PUBLISHED,
+        'localgov_event_date' => $this->getDate(-2),
+        'moderation_state' => 'published',
+      ]);
+      $past_event->save();
+    }
+
+    // Set up the configuration to unpublish events.
+    $config = \Drupal::configFactory()->getEditable('localgov_events_remove_expired.settings');
+    $config->set('expire_days', 1)
+      ->set('items_per_cron', 3)
+      ->set('action', 'unpublish')
+      ->save();
+
+    $this->cronRun();
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 0)
+      ->execute();
+
+    // 3 should be unpublished.
+    $this->assertEquals(3, count($nids), '3 events should be unpublished.');
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 1)
+      ->execute();
+
+    // 7 should be unpublished.
+    $this->assertEquals(7, count($nids), '7 events should remain published.');
+
+    // Run cron a 2nd time .
+    $this->cronRun();
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 0)
+      ->execute();
+
+    // 6 should be unpublished.
+    $this->assertEquals(6, count($nids), '6 events should be unpublished.');
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 1)
+      ->execute();
+
+    // 4 should be unpublished.
+    $this->assertEquals(4, count($nids), '4 events should remain published.');
+
+    // Run cron a 3rd time .
+    $this->cronRun();
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 0)
+      ->execute();
+
+    // 9 should be unpublished.
+    $this->assertEquals(9, count($nids), '9 events should be unpublished.');
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 1)
+      ->execute();
+
+    // 1 should be unpublished.
+    $this->assertEquals(1, count($nids), '1 events should remain published.');
+
+    // Run cron a 4th time .
+    $this->cronRun();
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 0)
+      ->execute();
+
+    // 10 should be unpublished.
+    $this->assertEquals(10, count($nids), '10 events should be unpublished.');
+
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(FALSE)
+      ->condition('type', 'localgov_event')
+      ->condition('status', 1)
+      ->execute();
+
+    // 1 should be unpublished.
+    $this->assertEquals(0, count($nids), '0 events should remain published.');
+
+  }
+
+  /**
+   * Create array events for testing.
+   *
+   * - Past event - 1 day past expiry period
+   * - Expiry period event - matches the expiry period
+   * - Todays event - 0 days old
+   * - Future event - an expiry period in the future
+   * - Recurring event - starts 2 days ago and recurs for 10 days.
+   *
+   * all events except the past event should remain published.
+   *
+   * @param int $expiryPeriod
+   *   The number of days after which an event expires.
+   * @param bool $moderation_flag
+   *   If true (default) set the moderation state to published.
+   */
+  private function createEvents(int $expiryPeriod, bool $moderation_flag = TRUE): array {
+
+    $events = [];
+
+    // Set up the events.
+    $newDate = (-($expiryPeriod + 1));
+    $pastEvent = $this->createEvent($newDate, $moderation_flag);
+
+    $this->drupalGet('node/' . $pastEvent->id());
+    $this->assertSession()->statusCodeEquals(200, 'The event is not accessible.');
+    $this->assertTrue($pastEvent->isPublished(), 'The event status is should be published.');
+    $events['past_event'] = $pastEvent;
+
+    $newDate = (-($expiryPeriod));
+    $expiryPeriodEvent = $this->createEvent($newDate, $moderation_flag);
+
+    $this->drupalGet('node/' . $expiryPeriodEvent->id());
+    $this->assertSession()->statusCodeEquals(200, 'The event is not accessible.');
+    $this->assertTrue($expiryPeriodEvent->isPublished(), 'The event status is should be published.');
+    $events['expiry_period_event'] = $expiryPeriodEvent;
+
+    $todayEvent = $this->createEvent(0, $moderation_flag);
+
+    $this->drupalGet('node/' . $todayEvent->id());
+    $this->assertSession()->statusCodeEquals(200, 'The event is not accessible.');
+    $this->assertTrue($todayEvent->isPublished(), 'The event status is should be published.');
+    $events['today_event'] = $todayEvent;
+
+    $newDate = ($expiryPeriod);
+    $futureEvent = $this->createEvent($newDate, $moderation_flag);
+
+    $this->drupalGet('node/' . $futureEvent->id());
+    $this->assertSession()->statusCodeEquals(200, 'The event is not accessible.');
+    $this->assertTrue($futureEvent->isPublished(), 'The event status is should be published.');
+    $events['future_event'] = $futureEvent;
+
+    // Create a 10 day recurring event with dates in the past and future.
+    $recurringEvent = $this->drupalCreateNode([
+      'type' => 'localgov_event',
+      'title' => 'Recurring with future events.',
+      'body' => 'This event has occurrences in the future and should remain.',
+      'status' => 1,
+      'localgov_event_date' => $this->getRecurringDate(),
+    ]);
+    if ($moderation_flag) {
+      $recurringEvent->set('moderation_state', 'published');
+    }
+    $recurringEvent->save();
+    $events['recurring_event'] = $recurringEvent;
+
+    $this->drupalGet('node/' . $recurringEvent->id());
+    $this->assertSession()->statusCodeEquals(200, 'The event is not accessible.');
+    $this->assertTrue($recurringEvent->isPublished(), 'The event status is should be published.');
+    $events['recurring_event'] = $recurringEvent;
+
+    return $events;
+  }
+
+  /**
+   * Create an event.
+   *
+   * @param int $new_date
+   *   Based on $new_date being:
+   *    - negative for past dates
+   *    - zero for today
+   *    - positive for future dates.
+   * @param bool $moderation_flag
+   *   If true (default) set the moderation state to published.
+   *
+   * @return array
+   *   The created node.
+   */
+  private function createEvent(int $new_date, bool $moderation_flag = TRUE):NodeInterface {
+
+    $title = $this->randomMachineName(8);
+    $node = $this->drupalCreateNode([
+      'title' => 'localgov_event ' . $title,
+      'type' => 'localgov_event',
+      'body' => 'LGD Event test page',
+      'status' => 1,
+      'localgov_event_date' => $this->getDate($new_date),
+    ]);
+    if ($moderation_flag) {
+      $node->set('moderation_state', 'published');
+    }
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Get an event date.
+   *
+   * Based on $new_date being:
+   *  - negative for past dates
+   *  - zero for today
+   *  - positive for future dates .
+   *
+   *  - all events are 2 hours long
+   *  - all dates are UTC and start at midnight
+   */
+  private function getDate(int $new_date): array {
+
+    $date = new DrupalDateTime('now', 'UTC');
+    $date->modify('midnight');
+    $start_date = $date->modify($new_date . " days")->format('Y-m-d\TH:i:s');
+
+    $end_date = $date->modify("+2 hours")->format('Y-m-d\TH:i:s');
+
+    return [
+      'value' => $start_date,
+      'end_value' => $end_date,
+      'rrule' => '',
+      'timezone' => 'UTC',
+    ];
+  }
+
+  /**
+   * Creates a 10 day recurring event.
+   *
+   * Starts 2 days ago and
+   * continues for 10 days.
+   */
+  private function getRecurringDate(): array {
+
+    $date = new DrupalDateTime('now', 'UTC');
+    $date->modify('midnight');
+    // Set date in the past, allowing for expire_days.
+    $start_date = $date->modify("-2 days")->format('Y-m-d\TH:i:s');
+    $end_date = $date->modify("+2 hours")->format('Y-m-d\TH:i:s');
+    return [
+      'value' => $start_date,
+      'end_value' => $end_date,
+      'timezone' => 'UTC',
+      'infinite' => 0,
+      'rrule' => 'FREQ=DAILY;COUNT=10',
+    ];
+  }
+
+}

--- a/modules/localgov_events_remove_expired/src/tests/Functional/PermissionsTest.php
+++ b/modules/localgov_events_remove_expired/src/tests/Functional/PermissionsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\localgov_events_remove_expired\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Functional tests for localgov_events_remove_expired permissions.
+ */
+class PermissionsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Skip schema checks.
+   *
+   * @var string[]
+   */
+  protected static $configSchemaCheckerExclusions = [
+    // Missing schema:
+    // - 'content.location.settings.reset_map.position'.
+    // - 'content.location.settings.weight'.
+    'core.entity_view_display.localgov_geo.area.default',
+    'core.entity_view_display.localgov_geo.area.embed',
+    'core.entity_view_display.localgov_geo.area.full',
+    'core.entity_view_display.geo_entity.area.default',
+    'core.entity_view_display.geo_entity.area.embed',
+    'core.entity_view_display.geo_entity.area.full',
+    // Missing schema:
+    // - content.location.settings.geometry_validation.
+    // - content.location.settings.multiple_map.
+    // - content.location.settings.leaflet_map.
+    // - content.location.settings.height.
+    // - content.location.settings.height_unit.
+    // - content.location.settings.hide_empty_map.
+    // - content.location.settings.disable_wheel.
+    // - content.location.settings.gesture_handling.
+    // - content.location.settings.popup.
+    // - content.location.settings.popup_content.
+    // - content.location.settings.leaflet_popup.
+    // - content.location.settings.leaflet_tooltip.
+    // - content.location.settings.map_position.
+    // - content.location.settings.weight.
+    // - content.location.settings.icon.
+    // - content.location.settings.leaflet_markercluster.
+    // - content.location.settings.feature_properties.
+    'core.entity_form_display.geo_entity.address.default',
+    'core.entity_form_display.geo_entity.address.inline',
+    // Missing schema:
+    // - content.postal_address.settings.providers.
+    // - content.postal_address.settings.geocode_geofield.
+    'core.entity_form_display.localgov_geo.address.default',
+    'core.entity_form_display.localgov_geo.address.inline',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_events_remove_expired',
+  ];
+
+  /**
+   * Test access permissions.
+   */
+  public function testConfigformUserAccess(): void {
+
+    // Check that anonymous user cannot access to the configuration page.
+    $this->drupalGet('/admin/config/content/expired-events');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
+
+    $normalAdminUser = $this->createUser(['access administration pages']);
+    $this->drupalLogin($normalAdminUser);
+
+    // Check that authenticated user cannot access to the configuration page.
+    $this->drupalGet('/admin/config/content/expired-events');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_FORBIDDEN);
+
+    // Create a user with permission to access the configuration page.
+    $eventsAdmin = $this->createUser(['administer expired events']);
+    $this->drupalLogin($eventsAdmin);
+    $this->drupalGet('/admin/config/content/expired-events');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+  }
+
+}


### PR DESCRIPTION
Release notes: 

> This release includes a new sub-module"LocalGov Events remove expired" which supports the automated removal of expired events. 
> 
> It provides a way to remove expired events - either by deletion or unpublishing/archiving A sub-module of localgov_events and works with or without content moderation.
> 
> When enabled, configuration options can be found at /admin/config/content/expired-events
> 
> Please see the README for more info. 
> 
> https://github.com/localgovdrupal/localgov_events/blob/3.x/modules/localgov_events_remove_expired/README.md
> 
  